### PR TITLE
Refactor: modify affectedEntities type

### DIFF
--- a/src/spaceone/monitoring/manager/phd_event_manager.py
+++ b/src/spaceone/monitoring/manager/phd_event_manager.py
@@ -220,7 +220,12 @@ class PersonalHealthDashboardManager(BaseManager):
                 detail_event = message.get(_key)
                 for detail_key in detail_event:
                     if detail_key in additional_info_key:
-                        additional_info.update({detail_key: detail_event.get(detail_key)})
+                        if detail_key == "affectedEntities":
+                            affected_entities = [affected_entity.get("entityValue", "")
+                                                 for affected_entity in detail_event.get(detail_key)]
+                            additional_info.update({detail_key: affected_entities})
+                        else:
+                            additional_info.update({detail_key: detail_event.get(detail_key)})
 
         return additional_info
 

--- a/src/spaceone/monitoring/model/phd_event_response_model.py
+++ b/src/spaceone/monitoring/model/phd_event_response_model.py
@@ -4,23 +4,13 @@ from schematics.types import DictType, StringType, ModelType, DateTimeType, Poly
 __all__ = ['EventModel']
 
 
-class Tags(Model):
-    stage = StringType(default='')
-    app = StringType(default='')
-
-
-class AffectedEntities(Model):
-    entityValue = StringType()
-    tags = ModelType(Tags, default={}, serialize_when_none=False)
-
-
 class HealthAdditionalInfo(Model):
     id = StringType(required=True)
     account = StringType(required=True)
     region = StringType()
     service = StringType(required=True)
     eventTypeCode = StringType()
-    affectedEntities = ListType(ModelType(AffectedEntities))
+    affectedEntities = ListType(StringType, default=[])
 
 
 class ResourceModel(Model):


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
AffectedEntities in additional_info need to be converted to string of list. [related issue : #39 ]
EX) For string values, extract only entityValue and save as list
['arn:aws:ec2:us-east 1:12345678:instance/i-abcd1111', 'arn:aws:ec2:us-east-1:12345678:instance/i -abcd1111' ]

The results of four test samples are as follows. All test sets passed.
```python
# Test sample 1(no affectedEntity)
{'results': [{'additional_info': {'account': '123456789012',
                                  'affectedEntities': [],
                                  'eventTypeCode': 'AWS_ELASTICLOADBALANCING_API_ISSUE',
                                  'id': '7bf73129-1428-4cd3-a780-95db273d1602',
                                  'region': 'ap-southeast-2',
                                  'service': 'ELASTICLOADBALANCING'}, ...

# Test sample 2(1 affectedEntity)
{'results': [{'additional_info': {'account': '123456789012',
                                  'affectedEntities': ['i-abcd1111'],
                                  'eventTypeCode': 'AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED',
                                  'id': '7bf73129-1428-4cd3-a780-95db273d1602',
                                  'region': 'us-west-2',
                                  'service': 'EC2'}, ...

# Test sample 3(2 affectedEntities)
{'results': [{'additional_info': {'account': '123456789012',
                                  'affectedEntities': ['arn:aws:ec2:us-east-1:123456789012:instance/i-abcd1111',
                                                       'arn:aws:ec2:us-east-1:123456789012:instance/i-abcd2222'],
                                  'eventTypeCode': 'AWS_ABUSE_DOS_REPORT',
                                  'id': '7bf73129-1428-4cd3-a780-95db273d1602',
                                  'region': 'global',
                                  'service': 'ABUSE'},

# Test sample 4(2 affectedEntities)
{'results': [{'additional_info': {'account': '123456789012',
                                  'affectedEntities': ['arn:aws:cloudfront::123456789012:distribution/DSF867DUMMY87SDF',
                                                       'arn:aws:ec2:us-east-1:123456789012:instance/i-abcd2222'],
                                  'eventTypeCode': 'AWS_ABUSE_COPYRIGHT_DMCA_REPORT',
                                  'id': '7bf73129-1428-4cd3-a780-95db273d1602',
                                  'region': 'global',
                                  'service': 'ABUSE'},
```